### PR TITLE
122: fix route for setting election

### DIFF
--- a/resources/views/elections/modals/elect.blade.php
+++ b/resources/views/elections/modals/elect.blade.php
@@ -31,7 +31,7 @@
     <div class="modal-footer">
         <button class="btn btn-success"
                 data-type="submit-modal"
-                data-form-action="{{ route('election.elect', ['electionId' => $election->id]) }}"
+                data-form-action="{{ route('election.elect', ['id' => $election->id]) }}"
                 data-redirect="true">
             <span class="fa fa-check"></span>
             <span>Save</span>


### PR DESCRIPTION
Fixes the link used to elect the selected committee. A while ago we renamed the `electionId` parameter to just `id` but seem to have missed this one. Tested locally because there's no automated tests :trollface:.

Fixes https://github.com/backstage-technical-services/hub/issues/122.