### PR TITLE
Remove space from accident report email address

### DIFF
--- a/config/bts.php
+++ b/config/bts.php
@@ -51,7 +51,7 @@ return [
                 'committee@bts-crew.com',
                 'safety@bts-crew.com',
                 'P.Hawker@bath.ac.uk',
-                'cw887@bath.ac.uk ',
+                'cw887@bath.ac.uk',
             ],
             'accident_receipt'  => [
                 'safety@bts-crew.com'


### PR DESCRIPTION
Removed one space from Claire Worrall's email address which was breaking the accident report form.