### PR TITLE
Updated the error link to point to github - Issues 133

### DIFF
--- a/resources/views/app/error.blade.php
+++ b/resources/views/app/error.blade.php
@@ -12,7 +12,7 @@
                     <a href="{{ route('home') }}">
                         <span class="fa fa-home" title="Try the homepage"></span>
                     </a>
-                    <a href="https://gitlab.com/backstage-technical-services/laravel-site/issues/new" target="_blank" title="Report issue">
+                    <a href="https://github.com/backstage-technical-services/hub/issues/new/choose" target="_blank" title="Report issue">
                         <span class="fa fa-gitlab"></span>
                     </a>
                 </div>

--- a/resources/views/app/includes/footer.blade.php
+++ b/resources/views/app/includes/footer.blade.php
@@ -26,7 +26,7 @@
             <a href="https://www.twitter.com/backstagetech" target="_blank">
                 <span class="fa fa-twitter" title="Follow us on twitter"></span>
             </a>
-            <a href="https://gitlab.com/backstage-technical-services/laravel-site/issues/new" target="_blank">
+            <a href="https://github.com/backstage-technical-services/hub/issues/new/choose" target="_blank">
                 <span class="fa fa-gitlab" title="Report an issue"></span>
             </a>
         </div>


### PR DESCRIPTION


### Issue summary

Updated the gitlab links to point to github in the error and footer blades.
The links now point to:
https://github.com/backstage-technical-services/hub/issues/new/choose



Ticket: https://github.com/backstage-technical-services/hub/issues/133

### Work included

searched the whole repo for the old gitlab links and updated them to github links. 

### Testing

Does the link go to the right place for reporting issues?

### Acceptance criteria
Have all the links been found?
Are they pointing to the correct page?

### Links

n/a

### Checklist

> Make sure you follow these wherever possible; if you have then check
> it off, and if not then use a strikethrough (\~) to cross it off.

**General**

* [ ] Readme updated (including additional environment variables)
* [ ] Additional documentation written (if applicable)
* [ ] Good coverage of tests
* [ ] Updated docker config
* [ ] CI/CD config updated
* [ ] Docker image builds and boots

**Principles**

* [ ] DRY, SOLID and Clean
* [ ] Follows language code style
* [ ] Use consistent vocabulary
* [ ] Any tech debt justified and ticketed where appropriate
* [ ] All data access audited
* [ ] Appropriate level of logging
