### PR TITLE
Fix Uncategorised Skill Bug

### DIFF
--- a/app/Http/Controllers/Training/Skills/SkillController.php
+++ b/app/Http/Controllers/Training/Skills/SkillController.php
@@ -57,7 +57,7 @@ class SkillController extends Controller
     {
         $skill = Skill::create([
             'name'        => clean($request->get('name')),
-            'category_id' => clean($request->get('category_id')),
+            'category_id' => clean($request->get('category_id')) ?: null,
             'description' => clean($request->get('description')),
             'level1'      => $request->has('available.level1') ? clean($request->get('level1')) : null,
             'level2'      => $request->has('available.level2') ? clean($request->get('level2')) : null,


### PR DESCRIPTION
Return null as category of uncategorised skills

### Issue summary
Creating new, uncategorised skills triggers HTTP Error 500.

Ticket: https://github.com/backstage-technical-services/hub/issues/132

### Work included

Convert Category ID to null if its value evaluates to false.

### Testing

Attempt to create a new, uncategorised skill.

### Acceptance criteria

Skill creates without an error 500.

**General**

* [x] ~~Readme updated (including additional environment variables)~~
* [x] ~~Additional documentation written (if applicable)~~
* [x] Good coverage of tests
* [x] ~~Updated docker config~~
* [x] ~~CI/CD config updated~~
* [x] Docker image builds and boots

**Principles**

* [x] DRY, SOLID and Clean
* [x] Follows language code style
* [x] Use consistent vocabulary
* [x] ~~Any tech debt justified and ticketed where appropriate~~
* [x] ~~All data access audited~~
* [x] ~~Appropriate level of logging~~