### PR TITLE
Don't include editablefields twice

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -27,7 +27,15 @@ return [
     'channels' => [
         'stack'    => [
             'driver'   => 'stack',
-            'channels' => ['daily', 'bugsnag'],
+            'channels' => ['monolog', 'bugsnag'],
+        ],
+        'monolog' => [
+            'driver' => 'monolog',
+            'handler' => Monolog\Handler\StreamHandler::class,
+            'handler_with' => [
+                'stream'   => storage_path('logs/laravel.log'),
+            ],
+            'formatter' => Monolog\Formatter\LineFormatter::class
         ],
         'single'   => [
             'driver' => 'single',

--- a/packages/WebDevTools/Laravel/Traits/UsesAjax.php
+++ b/packages/WebDevTools/Laravel/Traits/UsesAjax.php
@@ -2,6 +2,8 @@
 
 namespace Package\WebDevTools\Laravel\Traits;
 
+use Illuminate\Support\Facades\Log;
+
 trait UsesAjax
 {
     /**
@@ -17,6 +19,8 @@ trait UsesAjax
     protected function ajaxResponse($text, $status = 200, array $data = [], array $headers = [])
     {
         $data = array_merge($data, [($status == 200 ? 'response' : 'error') => $text]);
+
+        Log::debug("Sending JSON response", ['response' => response()->json($data, $status, $headers)]);
 
         return response()->json($data, $status, $headers);
     }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -74,7 +74,6 @@ mix
         'packages/WebDevTools/assets/js/plugins/ApplyDatetimePicker/auto-init.js',
         'packages/WebDevTools/assets/js/plugins/ApplySelect2/auto-init.js',
         'packages/WebDevTools/assets/js/plugins/DisableButtonOnClick/auto-init.js',
-        'packages/WebDevTools/assets/js/plugins/EditableFields/enable.js',
         'packages/WebDevTools/assets/js/plugins/OtherInput/auto-init.js',
         'packages/WebDevTools/assets/js/plugins/SimpleMDE/auto-init.js',
         'packages/WebDevTools/assets/js/plugins/ToggleVisibility/auto-init.js',


### PR DESCRIPTION
### Issue summary

We enable the _EditableFields_ package twice, so all AJAX calls are being done twice ... #awkward

I've also kept some of the logging I added to try and track this down.

Ticket: https://github.com/backstage-technical-services/hub/issues/135

### Work included

- Removes the 2nd initialisation of the _EditableFields_ JS package

### Testing

- Verify that you can volunteer/unvolunteer from events consistently
- Verify that you can approve awards consistently

### Acceptance criteria

N/A

### Links

- https://github.com/backstage-technical-services/hub/issues/135
- https://github.com/backstage-technical-services/hub/issues/136
- https://github.com/backstage-technical-services/hub/issues/137

### Checklist

> Make sure you follow these wherever possible; if you have then check
> it off, and if not then use a strikethrough (\~) to cross it off.

**General**

* [ ] ~Readme updated (including additional environment variables)~
* [ ] ~Additional documentation written (if applicable)~
* [ ] ~Good coverage of tests~
* [ ] ~Updated docker config~
* [ ] ~CI/CD config updated~
* [ ] ~Docker image builds and boots~

**Principles**

* [ ] ~DRY, SOLID and Clean~
* [ ] ~Follows language code style~
* [ ] ~Use consistent vocabulary~
* [ ] ~Any tech debt justified and ticketed where appropriate~
* [ ] ~All data access audited~
* [x] Appropriate level of logging
