### PR TITLE
Change email address for SU Technical Coordinator

### DIFF
--- a/config/bts.php
+++ b/config/bts.php
@@ -37,7 +37,7 @@ return [
         'events' => [
             'accepted_external' => [
                 'from'  => ['pm@bts-crew.com'],
-                'to'    => ['cw887@bath.ac.uk'],
+                'to'    => ['cjl25@bath.ac.uk'],
                 'cc'    => ['committee@bts-crew.com'],
                 'reply' => ['committee@bts-crew.com']
             ],
@@ -51,7 +51,7 @@ return [
                 'committee@bts-crew.com',
                 'safety@bts-crew.com',
                 'P.Hawker@bath.ac.uk',
-                'cw887@bath.ac.uk',
+                'cjl25@bath.ac.uk',
             ],
             'accident_receipt'  => [
                 'safety@bts-crew.com'


### PR DESCRIPTION
### Issue summary

Claire Worrall has left the SU and been replaced by Chris Lyon as SU Facilities & Technical Manager. Alter all instances of 'cw887@bath.ac.uk' to 'cjl25@bath.ac.uk'.

### Work included

Alter all instances of 'cw887@bath.ac.uk' to 'cjl25@bath.ac.uk'.

### Testing

No testing done as away from home and using online editor. If someone with a working environment could test it that would be great, but at the moment we're leaking information to someone outside the SU staff or the society and this is a simple email swap.

### Acceptance criteria

Claire Worrall no longer receives any emails that should go to SU staff, and Chris Lyon does.

### Links

None.

### Checklist

> Make sure you follow these wherever possible; if you have then check
> it off, and if not then use a strikethrough (\~) to cross it off.

**General**

* [ ] Readme updated (including additional environment variables)
* [ ] Additional documentation written (if applicable)
* [ ] Good coverage of tests
* [ ] Updated docker config
* [ ] CI/CD config updated
* [ ] Docker image builds and boots

**Principles**

* [ ] DRY, SOLID and Clean
* [ ] Follows language code style
* [ ] Use consistent vocabulary
* [ ] Any tech debt justified and ticketed where appropriate
* [ ] All data access audited
* [ ] Appropriate level of logging
