### PR TITLE
feat: disable scheduled backups

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,14 +33,6 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command(AutoCloseCrewLists::class)->daily();
-        $schedule->command(BackupDb::class)->daily();
-        $schedule->command(BackupCommand::class)
-                 ->weekly()
-                 ->then(
-                     function () use ($schedule) {
-                         $schedule->command(CleanupCommand::class);
-                     }
-                 );
     }
     
     /**


### PR DESCRIPTION
### Description

The backups aren't being cleaned up, but now we've moved to EKS and the storage is backed by EFS we don't really need to regularly back up the database or site resources. I've kept the commands though so we can still run those adhoc if we need, and people will still be able to manually make backups via the UI.

### Checklist

> [!IMPORTANT]
> Make sure you follow these wherever possible; if you have then check it off, and if not then use a strikethrough (\~)
> to cross it off. This will help the reviewer identify any changes that may have been missed.

**General**

* [ ] Documentation updated/written (if applicable)
* [ ] Good coverage of tests
* [ ] Updated docker config
* [ ] CI/CD config updated
* [ ] Docker image builds and boots

**Principles**

* [ ] DRY, SOLID and Clean
* [ ] Follows language code style
* [ ] Use consistent vocabulary
* [ ] Any tech debt justified and ticketed where appropriate
* [ ] All data access audited
* [ ] Appropriate level of logging
