### PR TITLE
feat: add hires email to booking request form

### DIFF
--- a/resources/views/contact/book.blade.php
+++ b/resources/views/contact/book.blade.php
@@ -16,6 +16,8 @@
         please note that this is not a confirmation that Backstage will crew your event. The Production Manager will get back to you with a definite answer as
         soon as possible.</p>
 
+    <p>Suppliers should contact <a href="mailto:hires@bts-crew.com">hires@bts-crew.com</a> for dry hires.</p>
+
     {!! Form::open() !!}
     <fieldset class="row">
         <legend>Event Details</legend>


### PR DESCRIPTION
<!-- PLEASE COMPLETE THIS TO THE BEST OF YOUR ABILITY -->

<!-- NOTE: your PR title will need to conform to the conventional commit spec -->

### Description

Committee have created a new email address for dry hires to help organise our inboxes. We would like to add a notice on the booking request form promoting this. 


